### PR TITLE
WEBSITE-284 Display "tags-1" tags

### DIFF
--- a/stylesheets/styles.scss
+++ b/stylesheets/styles.scss
@@ -380,9 +380,13 @@ footer.container {
   display: inline-block;
 }
 
-// Disable tags with less than 2 posts
-.tags-cloud .tags-0, .tags-cloud .tags-1 {
+.tags-cloud .tags-0 {
   display: none;
+}
+
+.tags-cloud .tags-1 {
+     font-size: 1.15em;
+     opacity: 0.85;
 }
 
 .tags-cloud .tags-2 {


### PR DESCRIPTION
This pull request will re-enable the tag link with class tags-1, showing again Hibernate OGM and Validator.

The problem is that a lot of tags will reappear again.

@emmanuelbernard this is related to this comment from @hferentschik:

>Apart from the fact that I don't quite understand how a bit of css can make this happen, I am also a bit surprised by the result. I like that is it now an actual tag cloud, but how does it work. For example, the quite important tags of 'Hibernate Valdiator' and 'Hibernate OGM'. Both are there in the plain tag list, but are gone in the cloud, even though they have more than one post against them and the tag url actually exists and I can browse the posts under this url. Feature? Bug? 