### PR TITLE
WEBSITE-282 Syntax highlighting for existing posts

### DIFF
--- a/_config/site.yml
+++ b/_config/site.yml
@@ -12,6 +12,8 @@ html_minifier: disabled
 # Disqus settings
 disqus_shortname: otnoitalerni-6
 
+legacy_post_syntax_highlighting: enabled
+
 ####################################################################################################
 # File merger
 ####################################################################################################
@@ -96,6 +98,7 @@ profiles:
     bootstrap_css_url: http://static.jboss.org/theme/css/bootstrap-community/2.3.1.3/bootstrap-community
     bootstrap_js_url: /javascripts/bootstrap-community
     #bootstrap_js_url: http://static.jboss.org/theme/js/libs/bootstrap-community/2.3.1.3/bootstrap-community
+    legacy_post_syntax_highlighting: disabled
   development:
     jborg_fonts_url: http://static.jboss.org/theme/fonts
     jborg_images_url: http://static.jboss.org/theme/images

--- a/_ext/legacy_post_code_highlighter.rb
+++ b/_ext/legacy_post_code_highlighter.rb
@@ -1,0 +1,47 @@
+##
+#
+# An extension of type transformer which modifies posts using the legacy syntax highlighting by replacing affected
+# <pre> blocks with an equivalent <pre> highlighted by CodeRay.
+#
+##
+module InRelationTo
+  module Extensions
+    class LegacyPostCodeHighlightingTransformer
+
+      def transform(site, page, input)
+
+        ext = File.extname(page.output_path)
+        if !ext.empty?
+          ext_txt = ext[1..-1]
+          if ext_txt == "html"
+
+            # Replace all <pre> blocks looking like this:
+            # <pre brush: java">...</pre>
+            while input =~ /(<pre.*?brush:\s*java.*?>)((.|\n)*?)(<\/pre>)/ do
+              listing = $2.gsub(/&#x000A;/, "\n")
+              listing.gsub!(/&gt;/, ">")
+              listing.gsub!(/&lt;/, "<")
+              listing = CodeRay.scan( listing, :java).html
+              listing = '<div class="listingblock"><div class="content"><pre class="CodeRay highlight"><code data-lang="Java">' + listing + "</code></pre></div></div>"
+              input.sub!(/<pre.*?brush:\s*java.*?>(.|\n)*?<\/pre>/, listing)
+            end
+
+            # Replace all <pre> blocks looking like this:
+            # <pre brush: xml">...</pre>
+            while input =~ /(<pre.*?brush:\s*xml.*?>)((.|\n)*?)(<\/pre>)/ do
+              listing = $2.gsub(/&#x000A;/, "\n")
+
+              listing.gsub!(/&gt;/, ">")
+              listing.gsub!(/&lt;/, "<")
+              listing = CodeRay.scan( listing, :xml).html
+              listing = '<div class="listingblock"><div class="content"><pre class="CodeRay highlight"><code data-lang="XML">' + listing + "</code></pre></div></div>"
+              input.sub!(/<pre.*?brush:\s*xml.*?>(.|\n)*?<\/pre>/, listing)
+            end
+          end
+        end
+
+        input
+      end
+    end
+  end
+end

--- a/_ext/legacy_post_code_highlighter.rb
+++ b/_ext/legacy_post_code_highlighter.rb
@@ -3,12 +3,18 @@
 # An extension of type transformer which modifies posts using the legacy syntax highlighting by replacing affected
 # <pre> blocks with an equivalent <pre> highlighted by CodeRay.
 #
+# The extension can be disabled by setting legacy_post_syntax_highlighting: disabled for a given profile. By default it
+# is enabled.
+#
 ##
 module InRelationTo
   module Extensions
     class LegacyPostCodeHighlightingTransformer
 
       def transform(site, page, input)
+        if !site.legacy_post_syntax_highlighting.nil? and !site.legacy_post_syntax_highlighting.to_s.eql?('enabled')
+          return input
+        end
 
         ext = File.extname(page.output_path)
         if !ext.empty?

--- a/_ext/pipeline.rb
+++ b/_ext/pipeline.rb
@@ -21,6 +21,7 @@ require 'atomizer'
 require 'paginator'
 require 'posts'
 
+require 'legacy_post_code_highlighter'
 
 # hack to add asciidoc support in HAML
 # remove once haml_contrib has accepted the asciidoc registration patch
@@ -99,6 +100,7 @@ Awestruct::Extensions::Pipeline.new do
   extension   Awestruct::Extensions::WgetWrapper.new
   extension   Awestruct::Extensions::FileMerger.new
   extension   Awestruct::Extensions::Indexifier.new
+  transformer InRelationTo::Extensions::LegacyPostCodeHighlightingTransformer.new
 
 end
 

--- a/_partials/head.html.haml
+++ b/_partials/head.html.haml
@@ -8,6 +8,7 @@
 - bootstrap_community_css = relative("#{pageStyle ? site[pageStyle].bootstrap_css_url : site.bootstrap_css_url}#{site.minified}.css", real_page)
 %link(href="#{bootstrap_community_css}" rel="stylesheet" media="screen")
 %link(href="#{relative("/stylesheets/styles.css", real_page)}" rel="stylesheet" media="screen")
+%link(href="#{relative("/stylesheets/coderay.css", real_page)}" rel="stylesheet" media="screen")
 / IE 6-8 support of HTML 5 elements
 /[if lt IE 9]
   %script(src="#{site.jborg_js_url}/libs/html5/pre3.6/html5.min.js")

--- a/stylesheets/coderay.css
+++ b/stylesheets/coderay.css
@@ -1,0 +1,130 @@
+.CodeRay {
+  background-color: hsl(0,0%,95%);
+  border: 1px solid silver;
+  color: black;
+}
+.CodeRay pre {
+  margin: 0px;
+}
+
+span.CodeRay { white-space: pre; border: 0px; padding: 2px; }
+
+table.CodeRay { border-collapse: collapse; width: 100%; padding: 2px; }
+table.CodeRay td { padding: 2px 4px; vertical-align: top; }
+
+.CodeRay .line-numbers {
+  background-color: hsl(180,65%,90%);
+  color: gray;
+  text-align: right;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  user-select: none;
+}
+.CodeRay .line-numbers a {
+  background-color: hsl(180,65%,90%) !important;
+  color: gray !important;
+  text-decoration: none !important;
+}
+.CodeRay .line-numbers pre {
+  word-break: normal;
+}
+.CodeRay .line-numbers a:target { color: blue !important; }
+.CodeRay .line-numbers .highlighted { color: red !important; }
+.CodeRay .line-numbers .highlighted a { color: red !important; }
+.CodeRay span.line-numbers { padding: 0px 4px; }
+.CodeRay .line { display: block; float: left; width: 100%; }
+.CodeRay .code { width: 100%; }
+
+.CodeRay .debug { color: white !important; background: blue !important; }
+
+.CodeRay .annotation { color:#007 }
+.CodeRay .attribute-name { color:#b48 }
+.CodeRay .attribute-value { color:#700 }
+.CodeRay .binary { color:#549 }
+.CodeRay .binary .char { color:#325 }
+.CodeRay .binary .delimiter { color:#325 }
+.CodeRay .char { color:#D20 }
+.CodeRay .char .content { color:#D20 }
+.CodeRay .char .delimiter { color:#710 }
+.CodeRay .class { color:#B06; font-weight:bold }
+.CodeRay .class-variable { color:#369 }
+.CodeRay .color { color:#0A0 }
+.CodeRay .comment { color:#777 }
+.CodeRay .comment .char { color:#444 }
+.CodeRay .comment .delimiter { color:#444 }
+.CodeRay .constant { color:#036; font-weight:bold }
+.CodeRay .decorator { color:#B0B }
+.CodeRay .definition { color:#099; font-weight:bold }
+.CodeRay .delimiter { color:black }
+.CodeRay .directive { color:#088; font-weight:bold }
+.CodeRay .docstring { color:#D42; }
+.CodeRay .doctype { color:#34b }
+.CodeRay .done { text-decoration: line-through; color: gray }
+.CodeRay .entity { color:#800; font-weight:bold }
+.CodeRay .error { color:#F00; background-color:#FAA }
+.CodeRay .escape  { color:#666 }
+.CodeRay .exception { color:#C00; font-weight:bold }
+.CodeRay .float { color:#60E }
+.CodeRay .function { color:#06B; font-weight:bold }
+.CodeRay .function .delimiter { color:#024; font-weight:bold }
+.CodeRay .global-variable { color:#d70 }
+.CodeRay .hex { color:#02b }
+.CodeRay .id  { color:#33D; font-weight:bold }
+.CodeRay .include { color:#B44; font-weight:bold }
+.CodeRay .inline { background-color: hsla(0,0%,0%,0.07); color: black }
+.CodeRay .inline-delimiter { font-weight: bold; color: #666 }
+.CodeRay .instance-variable { color:#33B }
+.CodeRay .integer  { color:#00D }
+.CodeRay .imaginary { color:#f00 }
+.CodeRay .important { color:#D00 }
+.CodeRay .key { color: #606 }
+.CodeRay .key .char { color: #60f }
+.CodeRay .key .delimiter { color: #404 }
+.CodeRay .keyword { color:#080; font-weight:bold }
+.CodeRay .label { color:#970; font-weight:bold }
+.CodeRay .local-variable { color:#950 }
+.CodeRay .map .content { color:#808 }
+.CodeRay .map .delimiter { color:#40A}
+.CodeRay .map { background-color:hsla(200,100%,50%,0.06); }
+.CodeRay .namespace { color:#707; font-weight:bold }
+.CodeRay .octal { color:#40E }
+.CodeRay .operator { }
+.CodeRay .predefined { color:#369; font-weight:bold }
+.CodeRay .predefined-constant { color:#069 }
+.CodeRay .predefined-type { color:#0a8; font-weight:bold }
+.CodeRay .preprocessor { color:#579 }
+.CodeRay .pseudo-class { color:#00C; font-weight:bold }
+.CodeRay .regexp { background-color:hsla(300,100%,50%,0.06); }
+.CodeRay .regexp .content { color:#808 }
+.CodeRay .regexp .delimiter { color:#404 }
+.CodeRay .regexp .modifier { color:#C2C }
+.CodeRay .reserved { color:#080; font-weight:bold }
+.CodeRay .shell { background-color:hsla(120,100%,50%,0.06); }
+.CodeRay .shell .content { color:#2B2 }
+.CodeRay .shell .delimiter { color:#161 }
+.CodeRay .string { background-color:hsla(0,100%,50%,0.05); }
+.CodeRay .string .char { color: #b0b }
+.CodeRay .string .content { color: #D20 }
+.CodeRay .string .delimiter { color: #710 }
+.CodeRay .string .modifier { color: #E40 }
+.CodeRay .symbol { color:#A60 }
+.CodeRay .symbol .content { color:#A60 }
+.CodeRay .symbol .delimiter { color:#740 }
+.CodeRay .tag { color:#070; font-weight:bold }
+.CodeRay .type { color:#339; font-weight:bold }
+.CodeRay .value { color: #088 }
+.CodeRay .variable { color:#037 }
+
+.CodeRay .insert { background: hsla(120,100%,50%,0.12) }
+.CodeRay .delete { background: hsla(0,100%,50%,0.12) }
+.CodeRay .change { color: #bbf; background: #007 }
+.CodeRay .head { color: #f8f; background: #505 }
+.CodeRay .head .filename { color: white; }
+
+.CodeRay .delete .eyecatcher { background-color: hsla(0,100%,50%,0.2); border: 1px solid hsla(0,100%,45%,0.5); margin: -1px; border-bottom: none; border-top-left-radius: 5px; border-top-right-radius: 5px; }
+.CodeRay .insert .eyecatcher { background-color: hsla(120,100%,50%,0.2); border: 1px solid hsla(120,100%,25%,0.5); margin: -1px; border-top: none; border-bottom-left-radius: 5px; border-bottom-right-radius: 5px; }
+
+.CodeRay .insert .insert { color: #0c0; background:transparent; font-weight:bold }
+.CodeRay .delete .delete { color: #c00; background:transparent; font-weight:bold }
+.CodeRay .change .change { color: #88f }
+.CodeRay .head .head { color: #f4f }


### PR DESCRIPTION
This adds syntax highlighting for existing posts via an Awestruct transformer that replaces `<pre>` blocks in the form of `<pre class="wikiPreformatted brush: java">...</pre>` with equivalent `<pre>`s highlighted using Coderay. Coderay is also what we use via Asciidoc, so the look is the same. Any thoughts?