### PR TITLE
WEBSITE-336 Hide bio when screen is too small

### DIFF
--- a/_data/people/DavideDAlto.md
+++ b/_data/people/DavideDAlto.md
@@ -2,4 +2,5 @@
 name: Davide D'Alto
 photo:
 level: 10
+gravatar_hash: bc527779e5d8d19744a62021d1b8afa3
 ---

--- a/stylesheets/blog-styles.scss
+++ b/stylesheets/blog-styles.scss
@@ -25,37 +25,37 @@ div.author-image > img {
 }
 
 @media (min-width: 768px) {
-  .cloud-authors, .cloud-tags, .divider {
+  .cloud-authors, .cloud-tags, .divider, .bio, .expandable {
     display: block;
   }
 }
 
 @media (max-width: 767px) {
-  .cloud-authors, .cloud-tags, .divider {
+  .cloud-authors, .cloud-tags, .divider, .bio, .expandable {
     display: none;
   }
 }
 
 @media (max-width: 470px) {
-  .cloud-authors, .cloud-tags, .project-menu .divider {
+  .cloud-authors, .cloud-tags, .project-menu .divider, .bio, .expandable {
     display: none;
   }
 }
 
 @media (max-width: 447px) {
-  .cloud-authors, .cloud-tags, .project-menu .divider {
+  .cloud-authors, .cloud-tags, .project-menu .divider, .bio, .expandable {
     display: none;
   }
 }
 
 @media (max-width: 365px) {
-  .cloud-authors, .cloud-tags, .project-menu .divider {
+  .cloud-authors, .cloud-tags, .project-menu .divider, .bio, .expandable {
     display: none;
   }
 }
 
 @media (max-width: 270px) {
-  .cloud-authors, .cloud-tags, .project-menu .divider {
+  .cloud-authors, .cloud-tags, .project-menu .divider, .bio, .expandable {
     display: none;
   }
 }


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/WEBSITE-336

With the current template it's not possible to place the bio at the bottom using only CSS.

This kind of feature can be obtain moving the column with the bio and the cloud to the right side (it also look nicer in my oipinion).

We can do it later if we want to.