### PR TITLE
WEBSITE-340 Setting the right page.title to make sure the HTML header…

### DIFF
--- a/_ext/paginator.rb
+++ b/_ext/paginator.rb
@@ -44,16 +44,17 @@ module Awestruct
       end
 
       def initialize(prop_name, input_path, opts={})
-        @prop_name    = prop_name
-        @input_path   = input_path
-        @per_page     = opts[:per_page] || 20
-        @per_page_init = opts[:per_page_init] || @per_page
-        @window_size  = opts[:window_size] || 2
-        @remove_input = opts.has_key?( :remove_input ) ? opts[:remove_input] : true
-        @output_prefix = opts[:output_prefix] || File.dirname( @input_path )
+        @prop_name        = prop_name
+        @input_path       = input_path
+        @per_page         = opts[:per_page] || 20
+        @per_page_init    = opts[:per_page_init] || @per_page
+        @window_size      = opts[:window_size] || 2
+        @remove_input     = opts.has_key?( :remove_input ) ? opts[:remove_input] : true
+        @output_prefix    = opts[:output_prefix] || File.dirname( @input_path )
         @output_home_file = opts[:output_home_file] || File.basename( @input_path )
-        @page_name     = opts[:page_name] || 'page/'
-        @collection    = opts[:collection]
+        @page_name        = opts[:page_name] || 'page/'
+        @collection       = opts[:collection]
+        @title            = opts[:title]
       end
 
       def execute(site)
@@ -75,6 +76,9 @@ module Awestruct
             page.output_path = File.join( @output_prefix, "#{@page_name}#{i}.html" )
           end
           page.paginate_generated = true
+          if !@title.nil?
+            page.title = @title
+          end
           site.pages << page
           paginated_pages << page
           i = i + 1

--- a/_ext/splitter.rb
+++ b/_ext/splitter.rb
@@ -7,6 +7,8 @@ module Awestruct
         attr_accessor :pages
         attr_accessor :group
         attr_accessor :primary_page
+        attr_accessor :split
+
         def initialize(split, pages)
           @split = split
           @pages = pages
@@ -14,13 +16,6 @@ module Awestruct
 
         def to_s
           @split
-        end
-      end
-
-      module SplitLinker
-        def split_links(delimiter = ', ', style_class = nil)
-          class_attr = (style_class ? ' class="' + style_class + '"' : '')
-          splits.map{|split| %Q{<a#{class_attr} href="#{split.primary_page.url}">#{split}</a>}}.join(delimiter)
         end
       end
 
@@ -57,7 +52,6 @@ module Awestruct
 
         all.each do |page|
           page.send( "#{@split_property}=", ( Array( page.send( @split_property ) ) ).collect{|t| @splits[t.to_s]} )
-          page.extend( SplitLinker )
         end
 
         ordered_splits = @splits.values
@@ -88,10 +82,15 @@ module Awestruct
           end
         end
 
-        @splits.values.each do |split|
+        @splits.each do |split_key, split|
           ## Optionally sanitize split URL
           output_prefix = File.join( @output_path, sanitize(split.to_s) )
-          options = { :remove_input=>false, :output_prefix=>output_prefix, :collection=>split.pages }.merge( @pagination_opts )
+          options = {
+           :remove_input=>false,
+           :output_prefix=>output_prefix,
+           :collection=>split.pages,
+           :title=>"#{site.title} #{split_key}"
+          }.merge( @pagination_opts )
 
           paginator = Awestruct::Extensions::Paginator.new( @split_items_property, @input_path, options )
           primary_page = paginator.execute( site )

--- a/_layouts/project.html.haml
+++ b/_layouts/project.html.haml
@@ -4,7 +4,7 @@
     -# display page title - project name if under a project section or page title - site name otherwise
     - project_id = page.project ? page.project : site.project
     - project_name = page.project ? site.projects[page.project].name : site.title
-    - page_title = "#{page.title ? page.title : page.simple_name.capitalize} - #{project_name ? project_name : site.title}"
+    - page_title = "#{page.title ? page.title : site.title }"
     %title= page_title
     = partial( page.head_partial.nil? ? 'head.html.haml' : page.head_partial, { "real_page" => page } )
 


### PR DESCRIPTION
… title can be properly set

- Updating the HAML template to avoid double "In relation to - In relation to"
- Adding additional option to Paginator to set the page title and making sure Splitter passes on the right title
- Removing unused SplitLinker