### PR TITLE
WEBSITE-318 Workaround for site re-generation. Instead of using the p…

### DIFF
--- a/_partials/blog/blogger_list.html.haml
+++ b/_partials/blog/blogger_list.html.haml
@@ -14,7 +14,8 @@
   %h2 Authors
   - for author in post_authors
     %div
-      %a{:href=>author.primary_page.url}
+      -# relying on primary_page.output_path instead of url which is for our purposes identical - see WEBSITE-318
+      %a{:href=>author.primary_page.output_path}
         = author.to_s
   .more-link
     %a{:href=>"/authors"}

--- a/_templates/split_cloud.html.haml
+++ b/_templates/split_cloud.html.haml
@@ -5,5 +5,6 @@
 %div{:class=>"#{page.split_property}-cloud"}
   - split_value = page.send( "#{page.split_property}" )
   - for split in split_value
+    -# relying on primary_page.output_path instead of url which is for our purposes identical - see WEBSITE-318
     %span{:class=>"#{page.split_property} #{page.split_property}-#{split.group}"}
-      %a{:href=>site.base_url + split.primary_page.url}= split
+      %a{:href=>site.base_url + split.primary_page.output_path}= split

--- a/_templates/tag.html.haml
+++ b/_templates/tag.html.haml
@@ -8,7 +8,8 @@ layout: in-relation-to
 - if not page.posts.nil?
   - post = page.posts[0]
   - for tag in post.tags
-    - tag_identifier = tag.primary_page.url.split("/")[-1].to_s
+    -# relying on primary_page.output_path instead of url which is for our purposes identical - see WEBSITE-318
+    - tag_identifier = tag.primary_page.output_path.split("/")[1].to_s
     - if tag_identifier == identifier
       - page_tag = tag
 


### PR DESCRIPTION
…age.url use page.output_path which for our purposes are identical

For some reason the page.url gets somehow re-set or maybe not set at all during re-generation. The extact cause is still unclear.
Instead rely on output_path which is always set
