### PR TITLE
Use stable branch 1.0 instead of master

### DIFF
--- a/posts/Mincong/2016-08-22-new-implementation-of-mass-indexer-using-jsr-352.adoc
+++ b/posts/Mincong/2016-08-22-new-implementation-of-mass-indexer-using-jsr-352.adoc
@@ -138,13 +138,14 @@ massIndexer = massIndexer.checkpointFreq( 1000 );
 == Run
 
 For further usage, please check my GitHub repo
-https://github.com/mincong-h/gsoc-hsearch[gsoc-hsearch]. If you want to play with it,
-you can download the code and build it with Maven: 
+https://github.com/mincong-h/gsoc-hsearch/tree/1.0[gsoc-hsearch]. If you want
+to play with it, you can download the code and build it with Maven: 
 
 [source]
 ----
 $ git clone -b 1.0 git://github.com/mincong-h/gsoc-hsearch.git
 $ cd gsoc-hsearch
+$ git checkout -b 1.0 origin/1.0
 $ mvn install
 ----
 


### PR DESCRIPTION
In the previous post, I used the link of the master branch of my repo. It should be better to use the stable branch [_1.0_](https://github.com/mincong-h/gsoc-hsearch/tree/1.0).
