### PR TITLE
Add a module to generate json feed from our posts for a given set of tags

### DIFF
--- a/_ext/json_feed_generator.rb
+++ b/_ext/json_feed_generator.rb
@@ -1,0 +1,94 @@
+require 'awestruct/context_helper'
+
+module InRelationTo
+  module Extensions
+    class JsonFeedGenerator
+
+      class TagStat
+        attr_accessor :entries
+        def initialize(tag, entries)
+          @tag   = tag
+          @entries = entries
+        end
+
+        def to_s
+          @tag
+        end
+      end
+
+      class BlogEntry
+        attr_accessor :title, :date, :snippet, :url
+
+        def initialize(title, date, snippet, url)
+          @title = title
+          @date = date
+          @snippet = snippet
+          @url = url
+        end
+
+        def as_json(options={})
+          {
+            title: @title,
+            date: @date,
+            snippet: @snippet,
+            url: @url
+          }
+        end
+
+        def to_json(*options)
+          as_json(*options).to_json(*options)
+        end
+      end
+
+      def initialize(entries, output_path='feeds', tags_to_generate, limit)
+        @entries = entries
+        @output_path = output_path
+        @tags_to_generate = tags_to_generate || {}
+        @limit = limit
+      end
+
+      def execute(site)
+        @tags = {}
+        @global_entries = []
+        entries = @entries.is_a?(Array) ? @entries : site.send( @entries ) || []
+        self.extend( Awestruct::ContextHelper )
+
+        entries.each do |entry|
+          feed_entry = site.engine.load_page(entry.source_path, :relative_path => entry.relative_source_path, :html_entities => false)
+          feed_entry.output_path = entry.output_path
+          feed_entry.date = feed_entry.timestamp.nil? ? entry.date : feed_entry.timestamp
+
+          if @global_entries.size <= @limit
+            @global_entries << BlogEntry.new( feed_entry.title, feed_entry.date, "#{summarize( html_to_text( feed_entry.content ), 50 )}", "#{site.base_url}#{feed_entry.output_path.chomp( 'index.html' )}" )
+          end
+
+          tags = entry.tags
+          if ( tags && ! tags.empty? )
+            tags.each do |tag|
+              tag = tag.to_s
+              next if ( !@tags_to_generate.include?(tag) || ( @tags.has_key?(tag) && @tags[tag].entries.size > @limit ) )
+              @tags[tag] ||= TagStat.new( tag, [] )
+              @tags[tag].entries << BlogEntry.new( feed_entry.title, feed_entry.date, "#{summarize( html_to_text( feed_entry.content ), 50 )}", "#{site.base_url}#{feed_entry.output_path.chomp( 'index.html' )}" )
+            end
+          end
+        end
+
+        feed_directory = File.join( site.config.output_dir, @output_path )
+        FileUtils.mkdir_p( feed_directory )
+
+        output_file = File.join( feed_directory, "global.json" )
+        File.open(output_file, 'w') do |f|
+          f.puts @global_entries.to_json
+        end
+        @tags_to_generate.each do |tag|
+          if @tags.has_key?(tag)
+            output_file = File.join( feed_directory, "#{tag.to_s.urlize({:convert_spaces=>true})}.json" )
+            File.open(output_file, 'w') do |f|
+              f.puts @tags[tag].entries.to_json
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/_ext/pipeline.rb
+++ b/_ext/pipeline.rb
@@ -21,6 +21,7 @@ require 'paginator'
 require 'posts'
 require 'date'
 require 'i18n'
+require 'json_feed_generator'
 
 # custom extensions
 require 'legacy_post_code_highlighter'
@@ -97,6 +98,8 @@ Awestruct::Extensions::Pipeline.new do
                                                    :template=>File.join(File.dirname(__FILE__), '../_templates/template.atom.haml'),
                                                    :feed_title=>'In Relation To Blog')
   end
+
+  extension InRelationTo::Extensions::JsonFeedGenerator.new( :posts, 'feeds', [ 'Hibernate ORM', 'Hibernate Search', 'Hibernate Validator', 'Hibernate OGM', 'JBoss Tools' ], 5)
 
   extension Awestruct::Extensions::Paginator.new( :posts, 'index', :per_page=>10, :per_page_init=>10 )
   extension InRelationTo::Extensions::PaginationLinkRenderer.new()


### PR DESCRIPTION
Related to https://hibernate.atlassian.net/projects/WEBSITE/issues/WEBSITE-484 .

@vladmihalcea @DavideD  I wrote a small Awestruct module to generate a JSON file for a set of defined tags (don't know what we currently use for the others page though).

To be able to use them from a remote site, we should probably use JSONP but most of the work is already done.

@vladmihalcea Could you take it over from there?

Thanks!