### PR TITLE
 [ORM] Hibernate ORM 5.4.4.Final release

### DIFF
--- a/posts/Andrea/2019-07-29-hibernate-orm-544-final-release.adoc
+++ b/posts/Andrea/2019-07-29-hibernate-orm-544-final-release.adoc
@@ -1,0 +1,31 @@
+= "Hibernate ORM 5.4.4.Final released"
+Andrea Boriero
+:awestruct-tags: [ "Hibernate ORM", "Releases" ]
+:awestruct-layout: blog-post
+:released-version: 5.4.4.Final
+:release-id: 31774
+---
+
+We just released the fourth maintenance release of Hibernate ORM 5.4 with significant performance improvements.
+
+
+== What's new
+
+This release introduces a new feature that allows enhanced entities to be returned in a completely uninitialized state delaying the load of expensive data until it's actually needed.  See http://in.relation.to/2019/07/29/bytecode-proxy[Bytecode enhancement as proxy] for details on this new feature.
+
+=== Bugfixes
+
+You can find the full list of changes in this version https://hibernate.atlassian.net/projects/HHH/versions/{release-id}/tab/release-report-all-issues[here] (or, for people without a Hibernate Jira account, https://hibernate.atlassian.net/secure/ReleaseNote.jspa?version={release-id}&styleName=Html&projectId=10031[here]).
+
+== Getting {released-version}
+
+All details are available and up to date on http://hibernate.org/orm/releases/5.4/#get-it[the dedicated page on hibernate.org].
+
+== Feedback, issues, ideas?
+
+To get in touch, use the usual channels:
+
+* https://stackoverflow.com/questions/tagged/hibernate[**hibernate** tag on Stack Overflow] (usage questions)
+* https://discourse.hibernate.org/c/hibernate-orm[User forum] (usage questions, general feedback)
+* https://hibernate.atlassian.net/browse/HHH[Issue tracker] (bug reports, feature requests)
+* http://lists.jboss.org/pipermail/hibernate-dev/[Mailing list] (development-related discussions)


### PR DESCRIPTION
It needs the PR https://github.com/hibernate/in.relation.to/pull/134 as it is referred in the release blog (http://in.relation.to/2019/07/29/bytecode-proxy)