### PR TITLE
Fixed microsoft typo

### DIFF
--- a/posts/Davide/2021-07-30-hibernate-reactive-1_0_0_CR9.adoc
+++ b/posts/Davide/2021-07-30-hibernate-reactive-1_0_0_CR9.adoc
@@ -8,7 +8,7 @@ Davide D'Alto
 
 Hibernate Reactive 1.0.0.CR9 is now available!
 
-This version includes the intregration with [Miscrosoft SQL Server](https://www.microsoft.com/en-gb/sql-server?rtc=1).
+This version includes the intregration with [Microsoft SQL Server](https://www.microsoft.com/en-gb/sql-server?rtc=1).
 You can find a complete list of changes on https://github.com/hibernate/hibernate-reactive/milestone/?closed=1[the Hibernate Reactive issue tracker].
 
 Thank you!
@@ -20,7 +20,7 @@ link:https://hibernate.org/reactive/releases/1.0/#get-it[Hibernate Reactive webs
 
 If you are new to Hibernate Reactive, {getting-started}[the official documentation] is a good place to start.
 
-== Microsfot SQL Server
+== Microsoft SQL Server
 
 You can use now Hibernate Reactive with Microsoft SQL Server. Like for the other databases, you will have
 to add the following dependencies to your project (using GAV coordinates):


### PR DESCRIPTION
The blog post in https://in.relation.to/2021/07/30/hibernate-reactive-1_0_0_CR9/ has some Microsoft typos