### PR TITLE
Blog post about Red Hat Middleware move to IBM

### DIFF
--- a/posts/Yoann/2025-03-24-red-hat-ibm.adoc
+++ b/posts/Yoann/2025-03-24-red-hat-ibm.adoc
@@ -1,0 +1,57 @@
+= About Red Hat and IBM
+Yoann Rodière
+:awestruct-tags: ["Red Hat", "IBM", "Community", "Commonhaus"]
+:awestruct-layout: blog-post
+
+A few weeks ago, Red Hat announced its Middleware division would move to IBM.
+As a change of this nature is likely to raise a few questions, we felt it would be best to provide some information.
+
+== What's happening?
+
+Red Hat employees from the Middleware division are being transferred to an equivalent division at IBM,
+with the initial target date set to May 2025.
+You can find more information in https://www.redhat.com/en/blog/evolving-our-middleware-strategy[the official announcement].
+
+These employees work for the most part on open-source Java technologies,
+for example Quarkus, whose team https://quarkus.io/blog/quarkus-redhat-strategy/[also commented on the move].
+
+When it comes to Hibernate, this affects several of our most active contributors,
+and in particular all project leaders.
+
+== What's the impact on Hibernate users and contributors?
+
+The displayed intent of the move is to keep funding open-source development, which implies no negative impact on the open-source software community.
+Early internal communication received by Hibernate team members was consistent with this,
+highlighting open-source development as a strategic investment.
+
+As a reminder, the Hibernate team has been working a lot on making our projects _more_ open in the past few months:
+the re-licensing of https://in.relation.to/2025/03/14/orm-asl/[Hibernate ORM]
+and https://in.relation.to/2024/06/10/hibernate-search-7-2-0-Alpha2/#switch-project-license-to-apache-license-2-0[Hibernate Search]
+from LGPL to ASL2 is now complete,
+and the https://in.relation.to/2024/04/09/hibernate-to-commonhaus/[move of Hibernate to the Commonhaus Foundation] is well under way,
+with the final steps being worked on as we speak.
+
+Also, yes, if you can believe it, these initiatives are a happy coincidence:
+the Hibernate team started them more than a year ago,
+while we were made aware of the move to IBM almost at the same time as everybody else, a few weeks ago.
+
+== What do Hibernate team members think about it?
+
+[quote,Steve Ebersole, Hibernate ORM project lead]
+____
+As I see it, the move from Red Hat to IBM is a simple matter of employment. Nothing will change in my day-to-day. Consider too that IBM acquired Red Hat nearly 6 years ago and there was hand-wringing even at that time about the future of Hibernate projects from some in the community. Yet here we are and the sky has not fallen.
+
+The take away, for me at least, is that Red Hat and now IBM have been very good stewards of our projects. The upcoming https://in.relation.to/2024/04/09/hibernate-to-commonhaus/[move to Commonhaus], I think, mitigates these fears even more - ensuring that Hibernate remains free, open-source and actively developed as community projects.
+____
+
+[quote,Marko Bekhta, Hibernate Validator and Hibernate Search project lead]
+____
+I contributed to Hibernate projects long before joining Red Hat; I am contributing to and maintaining Hibernate projects while I am at Red Hat. I don't see a reason not to continue doing so in the foreseeable future: I'll continue contributing to the Hibernate family of projects. Particularly because the projects we work on provide meaningful and practical solutions for problems software engineers encounter in their day-to-day work. As long as there's data -- you need to validate it, persist it, and search it.
+
+We have a great community and a lot of contributors beyond the core team. The colour of the logo won't change any of that.
+____
+
+== Comments?
+
+As usual, the https://hibernate.org/community/[Community page] provides all information necessary to reach out to the Hibernate team,
+be it to ask questions, report issues, or start contributing!

--- a/posts/Yoann/2025-03-24-red-hat-ibm.adoc
+++ b/posts/Yoann/2025-03-24-red-hat-ibm.adoc
@@ -4,7 +4,7 @@ Yoann Rodière
 :awestruct-layout: blog-post
 
 A few weeks ago, Red Hat announced its Middleware division would move to IBM.
-As a change of this nature is likely to raise a few questions, we felt it would be best to provide some information.
+As a change of this nature is likely to raise a few questions, I felt it would be best to provide some information -- even though the team as a whole is not yet ready to provide an official statement.
 
 == What's happening?
 
@@ -20,11 +20,12 @@ and in particular all project leaders.
 
 == What's the impact on Hibernate users and contributors?
 
-The displayed intent of the move is to keep funding open-source development, which implies no negative impact on the open-source software community.
-Early internal communication received by Hibernate team members was consistent with this,
+The displayed intent of the move is to keep funding open-source development,
+which implies no negative impact on the open-source software community.
+Early internal communication I received was consistent with this,
 highlighting open-source development as a strategic investment.
 
-As a reminder, the Hibernate team has been working a lot on making our projects _more_ open in the past few months:
+As a reminder, I (in part, but mostly the rest of the Hibernate team) have been working a lot on making our projects _more_ open in the past few months:
 the re-licensing of https://in.relation.to/2025/03/14/orm-asl/[Hibernate ORM]
 and https://in.relation.to/2024/06/10/hibernate-search-7-2-0-Alpha2/#switch-project-license-to-apache-license-2-0[Hibernate Search]
 from LGPL to ASL2 is now complete,
@@ -35,7 +36,10 @@ Also, yes, if you can believe it, these initiatives are a happy coincidence:
 the Hibernate team started them more than a year ago,
 while we were made aware of the move to IBM almost at the same time as everybody else, a few weeks ago.
 
-== What do Hibernate team members think about it?
+== Some quotes from Hibernate team members
+
+I took the liberty to collect quotes from fellow Hibernate team members.
+Note this reflects each person's opinion, and is not meant as an official statement from the whole team.
 
 [quote,Steve Ebersole, Hibernate ORM project lead]
 ____


### PR DESCRIPTION
To be sent on Monday, March 24th. I expect some discussion to be necessary, so today/tomorrow seems too soon.

Staging: https://staging.in.relation.to/2025/03/24/red-hat-ibm/

It's a first draft, so feel free to comment about what I should add or remove. I tried to stay simple, and to stick to facts.

This includes quotes from @sebersole and @marko-bekhta .

@beikov @DavideD @dreab8 @jrenaat @koentsje @mbladel @Sanne: I didn't receive a quote from you, but feel free to provide one (here or through DM) and I'll add it. Though of course, it's up to you (I'm personally not providing one).