### PR TITLE
Create blog post for Hibernate ORM 7.3.0.Final release

### DIFF
--- a/posts/Steve/2026-04-07-orm-73.adoc
+++ b/posts/Steve/2026-04-07-orm-73.adoc
@@ -1,0 +1,16 @@
+= Hibernate 7.3.0.Final
+Steve Ebersole
+:toc:
+:toclevels: 2
+:awestruct-tags: ["Hibernate ORM", "Releases"]
+:awestruct-layout: blog-post
+
+Hibernate ORM 7.3 Final was released a few weeks ago and today 7.3.1 will be released.
+
+Details about the release, as well as links to important resources, can be found at https://github.com/hibernate/hibernate-orm/releases/tag/7.3.0.
+
+Some of the new features include -
+
+1. Addition of the new `KeyType` enum that allows `find()` and `findMultiple()` to perform a load based on natural id in addition to identifier.
+2. Addition of `@NaturalIdClass` which models a non-aggregated composite natural id for the purpose of loading, very much like `@IdClass` does for non-aggregated identifiers.
+3. Support for Jackson 3 JSON and XML `FormatMapper` implementations


### PR DESCRIPTION
Added a new blog post about Hibernate ORM 7.3.0.Final release, detailing features and resources.