### PR TITLE
Create blog post for Hibernate ORM 7.4.0 release

### DIFF
--- a/posts/Steve/2026-05-26-orm-74.adoc
+++ b/posts/Steve/2026-05-26-orm-74.adoc
@@ -1,0 +1,17 @@
+= Hibernate 7.4.0.Final
+Steve Ebersole
+:toc:
+:toclevels: 2
+:awestruct-tags: ["Hibernate ORM", "Releases"]
+:awestruct-layout: blog-post
+
+Hibernate ORM 7.4 Final has been released.
+
+Details about the release, as well as links to important resources, can be found at https://github.com/hibernate/hibernate-orm/releases/tag/7.4.0.
+
+Some of the new features include -
+
+1. Support for `@Temporal` and `@Audited` data
+2. Support for database-generated columns (e.g. IDENTITY) within composite primary keys
+3. New `CacheMode.REFRESH_SESSION` alloowing that entities returned in a query result set should be efficiently refreshed in the first-level cache.
+4. Support for Google Cloud Spanner PostgreSQL-compatible Dialect


### PR DESCRIPTION
Added a new blog post about Hibernate ORM 7.4.0 release with details and features.