### PR TITLE
Fix titles containing colon-space being mangled by YAML.load

### DIFF
--- a/_ext/posts.rb
+++ b/_ext/posts.rb
@@ -6,6 +6,27 @@ module Awestruct
 
       attr_accessor :path_prefix, :assign_to, :archive_template, :archive_path, :default_layout, :wp_compat
 
+      # Awestruct's AsciidoctorHandler passes all parsed header values through
+      # YAML.load (see asciidoctor_handler.rb, parse_document_attributes).
+      # This is needed for attributes like :awestruct-tags: [ "Hibernate ORM" ]
+      # where the value is a YAML array, but it also applies to the document title.
+      #
+      # When a title contains ": " (colon-space), YAML.load interprets it as a
+      # mapping and returns a Hash instead of a String:
+      #
+      #   YAML.load("Main Title: A Subtitle")
+      #   => {"Main Title" => "A Subtitle"}    # Hash, not a String!
+      #
+      # This breaks layouts that expect page.title to be a String.
+      # The workaround so far has been to wrap titles in quotes in the .adoc source
+      # (= "Title: Subtitle"), but that's fragile and surprising for authors.
+      #
+      # This method reconstructs the original title string from the Hash.
+      def self.fix_title(page)
+        return unless page.title.is_a?(Hash)
+        page.title = page.title.map { |k, v| "#{k}: #{v}" }.join(', ')
+      end
+
       def initialize(path_prefix='', assign_to=:posts, archive_template=nil, archive_path=nil, opts={})
         @archive_template = archive_template
         @archive_path     = archive_path
@@ -20,6 +41,7 @@ module Awestruct
         archive = Archive.new
 
         site.pages.each do |page|
+          Posts.fix_title(page)
           year, month, day, slug = nil
 
           if ( page.relative_source_path =~ /^#{@path_prefix}\// )

--- a/posts/Davide/2015-12-21-hibernate-ogm-5-beta1-released.adoc
+++ b/posts/Davide/2015-12-21-hibernate-ogm-5-beta1-released.adoc
@@ -1,4 +1,4 @@
-= "Cassandra 2.2, @Lob mapping and @PostLoad support: Hibernate OGM 5.0.0.Beta1 released"
+= Cassandra 2.2, @Lob mapping and @PostLoad support: Hibernate OGM 5.0.0.Beta1 released
 Davide D'Alto
 :awestruct-tags: [ "Hibernate OGM", "Releases" ]
 :awestruct-layout: blog-post

--- a/posts/Davide/2016-03-30-hibernate-ogm-5-CR1-released.adoc
+++ b/posts/Davide/2016-03-30-hibernate-ogm-5-CR1-released.adoc
@@ -1,4 +1,4 @@
-= "Redis Cluster support, Redis hash mapping and more MongoDB CLI syntax: Hibernate OGM 5 CR1 released"
+= Redis Cluster support, Redis hash mapping and more MongoDB CLI syntax: Hibernate OGM 5 CR1 released
 Davide D'Alto
 :awestruct-tags: [ "Hibernate OGM", "Releases" ]
 :awestruct-layout: blog-post

--- a/posts/Guillaume/2016-06-29-Polishing-Polishing-And-More-Polishing-Hibernate-Search-5-5-4-Final.adoc
+++ b/posts/Guillaume/2016-06-29-Polishing-Polishing-And-More-Polishing-Hibernate-Search-5-5-4-Final.adoc
@@ -1,4 +1,4 @@
-= "Polishing, polishing and more polishing: Hibernate Search 5.5.4.Final is here!"
+= Polishing, polishing and more polishing: Hibernate Search 5.5.4.Final is here!
 Guillaume Smet
 :awestruct-tags: [ "Hibernate Search", "Releases" ]
 :awestruct-layout: blog-post

--- a/posts/Guillaume/2017-02-16-hibernate-validator-600-alpha1-out.adoc
+++ b/posts/Guillaume/2017-02-16-hibernate-validator-600-alpha1-out.adoc
@@ -1,4 +1,4 @@
-= "Initial Bean Validation 2.0 support: Hibernate Validator 6.0.0.Alpha1 is out"
+= Initial Bean Validation 2.0 support: Hibernate Validator 6.0.0.Alpha1 is out
 Guillaume Smet
 :awestruct-tags: [ "Hibernate Validator", "Releases" ]
 :awestruct-layout: blog-post

--- a/posts/Gunnar/2015-08-24-redis-support-hibernate-orm5-update-hibernate-ogm-50-alpha1-released.adoc
+++ b/posts/Gunnar/2015-08-24-redis-support-hibernate-orm5-update-hibernate-ogm-50-alpha1-released.adoc
@@ -1,4 +1,4 @@
-= "Redis support, Update to Hibernate ORM 5: Hibernate OGM 5.0.0.Alpha1 released"
+= Redis support, Update to Hibernate ORM 5: Hibernate OGM 5.0.0.Alpha1 released
 Gunnar Morling
 :awestruct-tags: [ "Hibernate OGM", "Releases" ]
 :awestruct-layout: blog-post

--- a/posts/Gunnar/2017-01-31-preventing-leaky-apis-with-jqassistant.adoc
+++ b/posts/Gunnar/2017-01-31-preventing-leaky-apis-with-jqassistant.adoc
@@ -1,4 +1,4 @@
-= "Tool Time: Preventing leaky APIs with jQAssistant"
+= Tool Time: Preventing leaky APIs with jQAssistant
 Gunnar Morling
 :awestruct-tags: [ "Discussions" ]
 :awestruct-layout: blog-post

--- a/posts/MarkoB/2025-09-29-hibernate-validator-benchmark.adoc
+++ b/posts/MarkoB/2025-09-29-hibernate-validator-benchmark.adoc
@@ -1,4 +1,4 @@
-= "Faster Than Ever: A Look at Hibernate Validator 9.1's Performance"
+= Faster Than Ever: A Look at Hibernate Validator 9.1's Performance
 Marko Bekhta
 :awestruct-tags: [ "Hibernate Validator", "Bean Validation", "Discussions" ]
 :awestruct-layout: blog-post

--- a/posts/Sanne/2016-04-26-Polishing-A-Great-Release-Hibernate-Search-5.5.3.Final.adoc
+++ b/posts/Sanne/2016-04-26-Polishing-A-Great-Release-Hibernate-Search-5.5.3.Final.adoc
@@ -1,4 +1,4 @@
-= "Polishing a great release: Hibernate Search 5.5.3.Final"
+= Polishing a great release: Hibernate Search 5.5.3.Final
 Sanne Grinovero
 :awestruct-tags: [ "Hibernate Search", "Releases" ]
 :awestruct-layout: blog-post

--- a/posts/Sanne/2020-02-14-hibernate-orm-5-4-12.adoc
+++ b/posts/Sanne/2020-02-14-hibernate-orm-5-4-12.adoc
@@ -1,4 +1,4 @@
-= "Showing some love for GraalVM: Hibernate ORM 5.4.12.Final is here"
+= Showing some love for GraalVM: Hibernate ORM 5.4.12.Final is here
 Sanne Grinovero
 :awestruct-tags: [ "Hibernate ORM", "Releases" ]
 :awestruct-layout: blog-post

--- a/posts/Sanne/2020-08-10-hibernate-orm-5.4.20.adoc
+++ b/posts/Sanne/2020-08-10-hibernate-orm-5.4.20.adoc
@@ -1,4 +1,4 @@
-= "Release: Hibernate ORM 5.4.20.Final"
+= Release: Hibernate ORM 5.4.20.Final
 Sanne Grinovero
 :awestruct-tags: [ "Hibernate ORM", "Releases" ]
 :awestruct-layout: blog-post

--- a/posts/Sanne/2020-10-01-hibernate-orm-5.4.22.adoc
+++ b/posts/Sanne/2020-10-01-hibernate-orm-5.4.22.adoc
@@ -1,4 +1,4 @@
-= "Release: Hibernate ORM 5.4.22.Final"
+= Release: Hibernate ORM 5.4.22.Final
 Sanne Grinovero
 :awestruct-tags: [ "Hibernate ORM", "Releases" ]
 :awestruct-layout: blog-post

--- a/posts/Sanne/2020-11-03-hibernate-orm-memory.adoc
+++ b/posts/Sanne/2020-11-03-hibernate-orm-memory.adoc
@@ -1,4 +1,4 @@
-= "Save some memory: upgrade to Hibernate ORM 5.4.23.Final"
+= Save some memory: upgrade to Hibernate ORM 5.4.23.Final
 Sanne Grinovero
 :awestruct-tags: [ "Hibernate ORM", "Releases" ]
 :awestruct-layout: blog-post

--- a/posts/Sanne/2021-01-07-hibernate-reactive-beta2.adoc
+++ b/posts/Sanne/2021-01-07-hibernate-reactive-beta2.adoc
@@ -1,4 +1,4 @@
-= "Hibernate Reactive: Beta 2"
+= Hibernate Reactive: Beta 2
 Sanne Grinovero
 :awestruct-tags: [ "Hibernate Reactive", "Releases" ]
 :awestruct-layout: blog-post

--- a/posts/Sanne/2021-09-14-ready-for-jdk17.adoc
+++ b/posts/Sanne/2021-09-14-ready-for-jdk17.adoc
@@ -1,4 +1,4 @@
-= "Hibernate: all systems go for Java 17"
+= Hibernate: all systems go for Java 17
 Sanne Grinovero
 :awestruct-tags: [ "Releases" ]
 :awestruct-layout: blog-post

--- a/posts/Sanne/2021-10-27-hibernate-reactive-performance.adoc
+++ b/posts/Sanne/2021-10-27-hibernate-reactive-performance.adoc
@@ -1,4 +1,4 @@
-= "Hibernate Reactive: is it worth it?"
+= Hibernate Reactive: is it worth it?
 Sanne Grinovero
 :awestruct-tags: [ "Hibernate Reactive", "Performance" ]
 :awestruct-layout: blog-post

--- a/posts/Stale/2026-08-19-hibernate-immutable-2lc-9x-speedup.adoc
+++ b/posts/Stale/2026-08-19-hibernate-immutable-2lc-9x-speedup.adoc
@@ -1,4 +1,4 @@
-= "When @Immutable Made All the Difference: A 3.2x Speedup with Hibernate Second-Level Cache"
+= When @Immutable Made All the Difference: A 3.2x Speedup with Hibernate Second-Level Cache
 Ståle Pedersen
 :awestruct-tags: [ "Hibernate ORM", "Performance", "JSON", "Caching" ]
 :awestruct-layout: blog-post


### PR DESCRIPTION
## Summary

- Awestruct's `AsciidoctorHandler` passes all parsed header values through `YAML.load`. When a title contains `: ` (colon-space), YAML interprets it as a mapping and returns a Hash instead of a String — breaking layouts that expect `page.title` to be a String.
- Added a `fix_title` method to the `Posts` extension that detects when `page.title` has been mangled into a Hash and reconstructs the original title string.
- Removed the double-quote workaround (`= "Title: Subtitle"`) from 16 existing posts that no longer need it.

## Test plan

- [ ] Run `rake clean gen` and verify the site builds without errors
- [ ] Spot-check a few posts with `: ` in the title (e.g. "Release: Hibernate ORM 5.4.22.Final", "Hibernate Reactive: Beta 2") to verify titles render correctly
- [ ] Verify existing posts whose titles were already quoted still render correctly