### PR TITLE
Upgrade to Semantic UI 2.5.0

### DIFF
--- a/_config/site.yml
+++ b/_config/site.yml
@@ -22,9 +22,9 @@ jborg_images_url: https://static.jboss.org/theme/images
 project_images_url: https://static.jboss.org/hibernate/images
 jquery_js_url: https://code.jquery.com/jquery-3.1.1
 jquery_js_url_integrity: "sha384-3ceskX3iaEnIogmQchP8opvBy3Mi7Ce34nWjpBIwVTHfGYWQS9jwHDVRnpKKHJg7"
-semantic_ui_js_url: https://cdn.jsdelivr.net/npm/semantic-ui@2.2.14/dist/semantic
-semantic_ui_js_url_integrity: "sha384-KfrAxmzWxzKdfquWGNOhm/N9kEjIgoP2yBPMQmAjQ+Is0hp+3BlcWT6PcI7NuKEP"
-semantic_ui_css_url: https://cdn.jsdelivr.net/npm/semantic-ui@2.2.14/dist/semantic
+semantic_ui_js_url: https://cdn.jsdelivr.net/npm/semantic-ui@2.5.0/dist/semantic
+semantic_ui_js_url_integrity: "sha384-J90C/4H4FEvN97dzFx745RBJDfRe8Lt+DQaL3uLYunPE2dagUsllBeEn5aZa4w8M"
+semantic_ui_css_url: https://cdn.jsdelivr.net/npm/semantic-ui@2.5.0/dist/semantic
 
 hibernate_org:
   base_url: https://hibernate.org/
@@ -67,7 +67,7 @@ profiles:
     html_minifier: disabled
     # Different checksums because we're not using the minified files
     jquery_js_url_integrity: "sha384-VC7EHu0lDzZyFfmjTPJq+DFyIn8TUGAJbEtpXquazFVr00Q/OOx//RjiZ9yU9+9m"
-    semantic_ui_js_url_integrity: "sha384-/OCHdyuUZjDPStDj7ti/VaVeGQ4U9HxuJhh0FNfMTf0eO1VeBLAam8EiKCIK+jso"
+    semantic_ui_js_url_integrity: "sha384-kIFKUWK+wdxfV8cJfSr4f3jPQNEOyf4LlPwR3ugvNq4nYKOrZnu1rTlVLzvo6eu9"
     legacy_post_syntax_highlighting: disabled
     ignore_older_than_days: 366
     disqus_shortname: staging-in-relation-to

--- a/stylesheets/styles.scss
+++ b/stylesheets/styles.scss
@@ -510,25 +510,16 @@ code, kbd, samp {
 		background: rgba(0, 0, 0, 0) none repeat scroll 0 0;
 	}
 
-	.fa.icon-note::before {
-		content: "";
+	@mixin admonition-icon($codepoint, $font: 'Icons') {
+		font-family: $font;
+		&::before { content: $codepoint; }
 	}
-
-	.fa.icon-tip::before {
-		content: "";
-	}
-
-	.fa.icon-warning::before {
-		content: "";
-	}
-
-	.fa.icon-caution::before {
-		content: "";
-	}
-
-	.fa.icon-important::before {
-		content: "";
-	}
+	// Semantic UI 2.5 icon codepoints for Asciidoc admonition blocks
+	.fa.icon-note      { @include admonition-icon("\f249", 'outline-icons'); } // sticky note outline
+	.fa.icon-tip       { @include admonition-icon("\f0eb", 'outline-icons'); } // lightbulb outline
+	.fa.icon-warning   { @include admonition-icon("\f071"); }                  // exclamation triangle
+	.fa.icon-caution   { @include admonition-icon("\f06d"); }                  // fire
+	.fa.icon-important { @include admonition-icon("\f071"); }                  // exclamation circle
 }
 
 .quoteblock {


### PR DESCRIPTION
## Summary
- Upgrade Semantic UI from 2.2.14 to 2.5.0 (CDN URLs and integrity hashes)
- Fix Asciidoc admonition icon overrides for the Font Awesome 4 → 5 transition:
  - Refactor into an SCSS mixin with correct codepoints and font families
  - Fix `icon-note` which used a codepoint that doesn't exist in FA5
  - Switch `icon-tip` to `outline-icons` font for consistent outline style

## Context
Same upgrade as https://github.com/hibernate/hibernate.org/pull/408. This repo is simpler — no `file.text.outline` template changes needed.

## Test plan
- [x] Verify admonition icons (note, tip, warning, caution, important) render correctly in blog posts
- [x] Spot-check other icons across the site